### PR TITLE
refactor(loaddictionary): only accept arraybuffer

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,8 +73,7 @@
   },
   "dependencies": {
     "hunspell-asm": "^2.0.0",
-    "tslib": "1.9.3",
-    "unixify": "1.0.0"
+    "tslib": "1.9.3"
   },
   "husky": {
     "hooks": {

--- a/spec/spellCheckerProvider-spec.ts
+++ b/spec/spellCheckerProvider-spec.ts
@@ -190,30 +190,6 @@ describe('spellCheckerProvider', () => {
       expect(provider.availableDictionaries).to.deep.equal(['kk']);
       expect(provider.selectedDictionary).to.be.null;
     });
-
-    it('should load file dictionary', async () => {
-      const mockMountDirectory = jest.fn(x => x);
-      const mockCreate = jest.fn();
-
-      const loadModuleMock = loadModule as jest.Mock<any>;
-      loadModuleMock.mockImplementationOnce(() => ({
-        mountDirectory: mockMountDirectory,
-        create: mockCreate
-      }));
-
-      const provider = new SpellCheckerProvider();
-      await provider.initialize();
-
-      await provider.loadDictionary('xx', '/x/a.dic', '/y/a.aff');
-      expect(mockMountDirectory.mock.calls).to.have.lengthOf(2);
-      expect(mockMountDirectory.mock.calls).to.deep.equal([['/y'], ['/x']]);
-
-      expect(mockCreate.mock.calls).to.have.lengthOf(1);
-      expect(mockCreate.mock.calls).to.deep.equal([['/y/a.aff', '/x/a.dic']]);
-
-      expect(provider.availableDictionaries).to.deep.equal(['xx']);
-      expect(provider.selectedDictionary).to.be.null;
-    });
   });
 
   describe('unloadDictionary', () => {
@@ -283,91 +259,6 @@ describe('spellCheckerProvider', () => {
 
       expect(mockUnmount.mock.calls).to.have.lengthOf(2);
       expect(mockChecker.dispose.mock.calls).to.have.lengthOf(1);
-    });
-
-    it('should unmount directory if refcount cleared', async () => {
-      const mockChecker = { dispose: jest.fn() };
-      const mockCreate = jest.fn(() => mockChecker);
-      const mockMountDirectory = jest.fn(x => x);
-      const mockUnmount = jest.fn();
-
-      const loadModuleMock = loadModule as jest.Mock<any>;
-      loadModuleMock.mockImplementationOnce(() => ({
-        mountDirectory: mockMountDirectory,
-        create: mockCreate,
-        unmount: mockUnmount
-      }));
-
-      const provider = new SpellCheckerProvider();
-      await provider.initialize();
-
-      await provider.loadDictionary('kk', '/x/a.dic', '/x/a.aff');
-
-      expect((provider as any).fileMountRefCount).to.deep.equal({ '/x': 2 });
-      provider.unloadDictionary('kk');
-
-      expect(mockUnmount.mock.calls).to.have.lengthOf(1);
-      expect((provider as any).fileMountRefCount).to.be.empty;
-    });
-
-    it('should not throw while decrease refcount for zero refs', async () => {
-      const mockChecker = { dispose: jest.fn() };
-      const mockCreate = jest.fn(() => mockChecker);
-      const mockMountDirectory = jest.fn(x => x);
-      const mockUnmount = jest.fn();
-
-      const loadModuleMock = loadModule as jest.Mock<any>;
-      loadModuleMock.mockImplementationOnce(() => ({
-        mountDirectory: mockMountDirectory,
-        create: mockCreate,
-        unmount: mockUnmount
-      }));
-
-      const provider = new SpellCheckerProvider();
-      await provider.initialize();
-
-      await provider.loadDictionary('kk', '/y/a.dic', '/x/a.aff');
-
-      expect((provider as any).fileMountRefCount).to.deep.equal({ '/x': 1, '/y': 1 });
-
-      //augment refcount to zero
-      (provider as any).fileMountRefCount['/x'] = 0;
-      provider.unloadDictionary('kk');
-
-      expect(mockUnmount.mock.calls).to.have.lengthOf(2);
-      expect((provider as any).fileMountRefCount).to.be.empty;
-    });
-
-    it('should decrease refcount file dictionary if mounted path have another dictionary', async () => {
-      const mockChecker = { dispose: jest.fn() };
-      const mockCreate = jest.fn(() => mockChecker);
-      const mockMountDirectory = jest.fn(x => x);
-      const mockUnmount = jest.fn();
-
-      const loadModuleMock = loadModule as jest.Mock<any>;
-      loadModuleMock.mockImplementationOnce(() => ({
-        mountDirectory: mockMountDirectory,
-        create: mockCreate,
-        unmount: mockUnmount
-      }));
-
-      const provider = new SpellCheckerProvider();
-      await provider.initialize();
-
-      await provider.loadDictionary('kk', '/x/a.dic', '/x/a.aff');
-      await provider.loadDictionary('xx', '/x/y.dic', '/x/y.aff');
-
-      expect((provider as any).fileMountRefCount).to.deep.equal({ '/x': 4 });
-
-      provider.unloadDictionary('kk');
-
-      expect(mockUnmount.mock.calls).to.have.lengthOf(0);
-      expect((provider as any).fileMountRefCount).to.deep.equal({ '/x': 2 });
-
-      provider.unloadDictionary('xx');
-
-      expect(mockUnmount.mock.calls).to.have.lengthOf(1);
-      expect((provider as any).fileMountRefCount).to.be.empty;
     });
   });
 

--- a/src/ambient.d.ts
+++ b/src/ambient.d.ts
@@ -1,1 +1,0 @@
-declare module 'unixify';


### PR DESCRIPTION
BREAKING CHANGE: loadDictionary does not read physical file from path anymore

This PR changes interface to `loadDictionary` to accept arrayBuffer only. Previously it also accepts physical path to dic / aff and read it, mount into wasm's memory space. For the preparation of electron's new async spellchecker, it is expected to create instance of provider in any context like worker, or renderer, vice versa - and detecting & supporting various env to load dictionary is non trivial job.

Any env should able to create arraybuffer from file contents instead - in main process `fs` can read file into buffer, and any other renderer process `fetch` or similar allows to retrieve contents from remote endpoint. Spellchecker provider now expects per-context handling occurs in caller's side.