### PR TITLE
feat(attachspellcheckerprovider): implement attach spellchecker provider

### DIFF
--- a/example/browserView-preload.ts
+++ b/example/browserView-preload.ts
@@ -15,7 +15,7 @@ const init = async () => {
     path.join(path.resolve('./'), 'en-US.dic'),
     path.join(path.resolve('./'), 'en-US.aff')
   );
-  setTimeout(async () => browserViewProvider.switchDictionary('en'), 3000);
+  setTimeout(async () => browserViewProvider.onSwitchLanguage('en'), 3000);
 };
 
 init();

--- a/example/browserWindow.ts
+++ b/example/browserWindow.ts
@@ -23,7 +23,7 @@ const init = async () => {
     path.join(path.resolve('./'), 'en-US.aff')
   );
 
-  browserWindowProvider.switchDictionary('en');
+  browserWindowProvider.onSwitchLanguage('en');
 };
 
 init();

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -5,15 +5,15 @@
   "requires": true,
   "dependencies": {
     "@types/node": {
-      "version": "10.12.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.21.tgz",
-      "integrity": "sha512-CBgLNk4o3XMnqMc0rhb6lc77IwShMEglz05deDcn2lQxyXEZivfwgYJu7SMha9V5XcrP6qZuevTHV/QrN2vjKQ==",
+      "version": "10.14.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.7.tgz",
+      "integrity": "sha512-on4MmIDgHXiuJDELPk1NFaKVUxxCFr37tm8E9yN6rAiF5Pzp/9bBfBHkoexqRiY+hk/Z04EJU9kKEb59YqJ82A==",
       "dev": true
     },
     "ajv": {
-      "version": "6.8.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.8.1.tgz",
-      "integrity": "sha512-eqxCp82P+JfqL683wwsL73XmFs1eG6qjw+RD3YHx+Jll1r0jNd4dh8QG9NYAeNGA/hnZjeEDgtTskgJULbxpWQ==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+      "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^2.0.1",
@@ -186,9 +186,9 @@
       "dev": true
     },
     "combined-stream": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
-      "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
@@ -354,9 +354,9 @@
       }
     },
     "electron": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-4.0.4.tgz",
-      "integrity": "sha512-zG5VtLrmPfmw1fXY/3BEtRZk7OZ7djQhweZ6rW+R5NeF6s8RTz/AwTGtLoBo4z8wmJ5QTy0Y941FZw4pe5YlpA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-5.0.1.tgz",
+      "integrity": "sha512-8KksyhAPcpXVeO8ViVGxfZAuf8yEVBCtV0h/lMBD8VFbCQ9icej1K5csCFAGirbZbqOz5IdsBZX9Gpb9n4RCag==",
       "dev": true,
       "requires": {
         "@types/node": "^10.12.18",
@@ -900,18 +900,18 @@
       }
     },
     "mime-db": {
-      "version": "1.37.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
-      "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg==",
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.21",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
-      "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
+      "version": "2.1.24",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+      "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
       "dev": true,
       "requires": {
-        "mime-db": "~1.37.0"
+        "mime-db": "1.40.0"
       }
     },
     "minimatch": {

--- a/example/package.json
+++ b/example/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "devDependencies": {
     "cross-env": "^5.2.0",
-    "electron": "^4.0.4",
+    "electron": "^5.0.1",
     "npm-run-all": "^4.1.5",
     "shx": "^0.3.2",
     "typescript": "^3.3.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2587,9 +2587,9 @@
       }
     },
     "electron": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-4.2.1.tgz",
-      "integrity": "sha512-v1pwY6PQ+ITVkV/QGgEAEjoBGnPIuut80M+GseWkLcIJ+mIN3xbpuhd1v6arJ1XV7H6waNwjtIFgGSmVWWNRhw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-5.0.1.tgz",
+      "integrity": "sha512-8KksyhAPcpXVeO8ViVGxfZAuf8yEVBCtV0h/lMBD8VFbCQ9icej1K5csCFAGirbZbqOz5IdsBZX9Gpb9n4RCag==",
       "dev": true,
       "requires": {
         "@types/node": "^10.12.18",
@@ -2598,9 +2598,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.14.6",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.6.tgz",
-          "integrity": "sha512-Fvm24+u85lGmV4hT5G++aht2C5I4Z4dYlWZIh62FAfFO/TfzXtPpoLI6I7AuBWkIFqZCnhFOoTT7RjjaIL5Fjg==",
+          "version": "10.14.7",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.7.tgz",
+          "integrity": "sha512-on4MmIDgHXiuJDELPk1NFaKVUxxCFr37tm8E9yN6rAiF5Pzp/9bBfBHkoexqRiY+hk/Z04EJU9kKEb59YqJ82A==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "commitizen": "^3.1.1",
     "conventional-changelog-cli": "^2.0.21",
     "cz-conventional-changelog": "2.1.0",
-    "electron": "^4.2.1",
+    "electron": "^5.0.1",
     "husky": "^2.3.0",
     "jest": "^24.8.0",
     "jest-spin-reporter": "^1.0.2",

--- a/spec/spellCheckerProvider-spec.ts
+++ b/spec/spellCheckerProvider-spec.ts
@@ -266,7 +266,7 @@ describe('spellCheckerProvider', () => {
     it('should throw if dictionary is not available', () => {
       const provider = new SpellCheckerProvider();
 
-      expect(() => provider.switchDictionary('k')).to.throw();
+      expect(() => provider.onSwitchLanguage('k')).to.throw();
     });
 
     it('should log uptime if current dictionary exists', () => {
@@ -281,7 +281,7 @@ describe('spellCheckerProvider', () => {
       };
       Date.now = jest.fn(() => 100);
 
-      provider.switchDictionary('ll');
+      provider.onSwitchLanguage('ll');
       const uptime = (provider as any).spellCheckerTable['kk'].uptime;
       expect(uptime).to.equal(95); //100 - 10 + 5
       Date.now = _now;
@@ -298,7 +298,7 @@ describe('spellCheckerProvider', () => {
       };
       Date.now = jest.fn(() => 100);
 
-      provider.switchDictionary('ll');
+      provider.onSwitchLanguage('ll');
       const uptime = (provider as any).spellCheckerTable['kk'].uptime;
       expect(uptime).to.equal(5);
       Date.now = _now;
@@ -311,7 +311,7 @@ describe('spellCheckerProvider', () => {
       };
 
       expect((provider as any).currentSpellCheckerStartTime).to.equal(Number.NEGATIVE_INFINITY);
-      provider.switchDictionary('ll');
+      provider.onSwitchLanguage('ll');
 
       expect((provider as any).currentSpellCheckerStartTime).to.be.greaterThan(0);
     });
@@ -322,7 +322,7 @@ describe('spellCheckerProvider', () => {
         ll: {}
       };
 
-      expect(() => provider.switchDictionary('ll')).to.not.throw();
+      expect(() => provider.onSwitchLanguage('ll')).to.not.throw();
     });
 
     it('should attach into webframe', () => {
@@ -338,7 +338,7 @@ describe('spellCheckerProvider', () => {
         }
       };
 
-      provider.switchDictionary('ll');
+      provider.onSwitchLanguage('ll');
       expect(provider.selectedDictionary).to.equal('ll');
       const calls = (webFrame.setSpellCheckProvider as jest.Mock<any>).mock.calls;
       expect(calls).to.have.lengthOf(1);
@@ -367,7 +367,7 @@ describe('spellCheckerProvider', () => {
         }
       };
 
-      provider.switchDictionary('ll');
+      provider.onSwitchLanguage('ll');
       expect(provider.selectedDictionary).to.equal('ll');
       const calls = (webFrame.setSpellCheckProvider as jest.Mock<any>).mock.calls;
       expect(calls).to.have.lengthOf(1);

--- a/src/attachSpellCheckerProvider.ts
+++ b/src/attachSpellCheckerProvider.ts
@@ -1,12 +1,34 @@
 import { log } from './util/logger';
 
+/**
+ * Interface to spell checker provider proxy can be accessed from renderer process.
+ * `attachSpellCheckProvider` will use this proxy to communicate to actual provider.
+ */
 interface ProviderProxy {
-  spell: (text: string) => Promise<boolean>;
-  getSuggestion: (text: string) => Promise<Readonly<Array<string>>>;
+  /**
+   * Notify provider to current spellchecker language changed.
+   * Provider should handle this for subsequent `spell`, `getSuggestion`, `getSelectedDictionaryLanguage` request.
+   */
   onSwitchLanguage: (languageKey: string) => Promise<void>;
+  /**
+   * Request to check spell for word with currently selected language.
+   */
+  spell: (text: string) => Promise<boolean>;
+  /**
+   * Request to get spell suggestion for word with currently selected language.
+   */
+  getSuggestion: (text: string) => Promise<Readonly<Array<string>>>;
+  /**
+   * Returns currently selected spellchecker dictionary language.
+   */
   getSelectedDictionaryLanguage: () => Promise<string | null>;
 }
 
+/**
+ * Attach spellchecker callback to current webFrame.
+ *
+ * @param providerProxy
+ */
 const attachSpellCheckProvider = async (providerProxy: ProviderProxy) => {
   const { webFrame }: { webFrame: typeof import('electron').webFrame } = require('electron'); //tslint:disable-line:no-var-requires no-require-imports
 
@@ -29,11 +51,16 @@ const attachSpellCheckProvider = async (providerProxy: ProviderProxy) => {
   };
 
   return {
+    /**
+     * Change language for spellchecker attached to webFrame.
+     */
     switchLanguage: (languageKey: string) => {
       webFrame.setSpellCheckProvider(languageKey, spellCheckerCallback);
       return providerProxy.onSwitchLanguage(languageKey);
     },
-
+    /**
+     * Teardown webFrame's spellchecker based on current language.
+     */
     unsubscribe: async () => {
       const currentLanguageKey = await providerProxy.getSelectedDictionaryLanguage();
       if (currentLanguageKey) {

--- a/src/attachSpellCheckerProvider.ts
+++ b/src/attachSpellCheckerProvider.ts
@@ -1,0 +1,50 @@
+import { log } from './util/logger';
+interface ProviderProxy {
+  spell: (languageKey: string, text: string) => Promise<boolean>;
+  getSuggestion: (languageKey: string, text: string) => Promise<Readonly<Array<string>>>;
+}
+
+const attachSpellCheckProvider = async (providerProxy: ProviderProxy) => {
+  const { webFrame }: { webFrame: typeof import('electron').webFrame } = require('electron'); //tslint:disable-line:no-var-requires no-require-imports
+
+  if (!webFrame) {
+    throw new Error(`attach: Cannot lookup webFrame to set spell checker provider`);
+  }
+
+  let currentLanguageKey: string | null = null;
+
+  const spellCheckerCallback = {
+    spellCheck: (words: Array<string>, completionCallback: (misspeltWords: string[]) => void) => {
+      if (!currentLanguageKey) {
+        completionCallback([]);
+        return;
+      }
+
+      const wordsCheckSpell = words.map(word =>
+        providerProxy.spell(currentLanguageKey!, word).then(isCorrectSpell => (isCorrectSpell ? null : word))
+      );
+      Promise.all(wordsCheckSpell).then(
+        results => completionCallback(results.filter((word => !!word) as (w: any) => w is string)),
+        error => log.error(`spellCheckerCallback: failed to check spell`, error)
+      );
+    }
+  };
+
+  return {
+    switchLanguage: (languageKey: string) => {
+      currentLanguageKey = languageKey;
+      webFrame.setSpellCheckProvider(currentLanguageKey, spellCheckerCallback);
+    },
+
+    unsubscribe: () => {
+      if (currentLanguageKey) {
+        webFrame.setSpellCheckProvider(currentLanguageKey, {
+          spellCheck: (_, cb) => cb([])
+        });
+        currentLanguageKey = null;
+      }
+    }
+  };
+};
+
+export { ProviderProxy, attachSpellCheckProvider };

--- a/src/spellCheckerProvider.ts
+++ b/src/spellCheckerProvider.ts
@@ -60,6 +60,13 @@ class SpellCheckerProvider {
     log.info(`loadAsmModule: asm module loaded successfully`);
   }
 
+  /**
+   * Callback to be called by `attachSpellCheckerProvider` when requested to change
+   * webFrame's spellchecker language. This calback will set current spellchecker instance in
+   * provider to be used subsequent spell / suggestion request.
+   *
+   * @param {string} languageKey Locale key for spell checker instance.
+   */
   public async onSwitchLanguage(languageKey: string): Promise<void> {
     if (!languageKey || !this.spellCheckerTable[languageKey]) {
       throw new Error(`Spellchecker dictionary for ${languageKey} is not available, ensure dictionary loaded`);

--- a/src/spellCheckerProvider.ts
+++ b/src/spellCheckerProvider.ts
@@ -69,17 +69,13 @@ class SpellCheckerProvider {
     log.info(`loadAsmModule: asm module loaded successfully`);
   }
 
-  /**
-   * Set current spell checker instance for given locale key then attach into current webFrame.
-   * @param {string} key Locale key for spell checker instance.
-   */
-  public switchDictionary(key: string): void {
-    if (!key || !this.spellCheckerTable[key]) {
-      throw new Error(`Spellchecker dictionary for ${key} is not available, ensure dictionary loaded`);
+  public onSwitchLanguage(languageKey: string): void {
+    if (!languageKey || !this.spellCheckerTable[languageKey]) {
+      throw new Error(`Spellchecker dictionary for ${languageKey} is not available, ensure dictionary loaded`);
     }
 
     log.info(
-      `switchDictionary: switching dictionary to check spell from '${this._currentSpellCheckerKey}' to '${key}'`
+      `switchDictionary: switching dictionary to check spell from '${this._currentSpellCheckerKey}' to '${languageKey}'`
     );
 
     if (Number.isInteger(this.currentSpellCheckerStartTime)) {
@@ -92,7 +88,7 @@ class SpellCheckerProvider {
     }
 
     this.currentSpellCheckerStartTime = Date.now();
-    this._currentSpellCheckerKey = key;
+    this._currentSpellCheckerKey = languageKey;
   }
 
   /**

--- a/src/spellCheckerProvider.ts
+++ b/src/spellCheckerProvider.ts
@@ -156,7 +156,7 @@ class SpellCheckerProvider {
    */
   public unloadDictionary(languageKey: string): void {
     if (!languageKey || !this.spellCheckerTable[languageKey]) {
-      log.info(`unloadDictionary: not able to find corresponding spellchecker for given key`);
+      log.info(`unloadDictionary: not able to find corresponding spellchecker for given key '${languageKey}'`);
       return;
     }
 
@@ -165,7 +165,6 @@ class SpellCheckerProvider {
       this.currentSpellCheckerStartTime = Number.NEGATIVE_INFINITY;
 
       log.warn(`unloadDictionary: unload dictionary for current spellchecker instance`);
-      this.setProvider(languageKey, () => true);
     }
 
     const dict = this.spellCheckerTable[languageKey];

--- a/src/spellCheckerProvider.ts
+++ b/src/spellCheckerProvider.ts
@@ -82,24 +82,27 @@ class SpellCheckerProvider {
     this._currentSpellCheckerKey = languageKey;
   }
 
+  public async spell(text: string): Promise<boolean> {
+    const spellChecker = this.getSpellchecker();
+    if (!spellChecker) {
+      throw new Error('Not able to find spellchecker');
+    }
+
+    return spellChecker.spell(text);
+  }
+
   /**
    * Get suggestion for misspelled text.
    * @param {string} Text text to get suggstion.
    * @returns {Readonly<Array<string>>} Array of suggested values.
    */
   public async getSuggestion(text: string): Promise<Readonly<Array<string>>> {
-    if (!this._currentSpellCheckerKey) {
-      log.warn(`getSuggestedWord: there isn't any spellchecker key, bailing`);
-      return [];
+    const spellChecker = this.getSpellchecker();
+    if (!spellChecker) {
+      throw new Error('Not able to find spellchecker');
     }
 
-    const checker = this.spellCheckerTable[this._currentSpellCheckerKey];
-    if (!checker) {
-      log.error(`attach: There isn't corresponding dictionary for key '${this._currentSpellCheckerKey}'`);
-      return [];
-    }
-
-    return checker.spellChecker.suggest(text);
+    return spellChecker.suggest(text);
   }
 
   /**
@@ -154,6 +157,21 @@ class SpellCheckerProvider {
 
     delete this.spellCheckerTable[languageKey];
     log.info(`unloadDictionary: dictionary for '${languageKey}' is unloaded`);
+  }
+
+  private getSpellchecker() {
+    if (!this._currentSpellCheckerKey) {
+      log.warn(`getSuggestedWord: there isn't any spellchecker key, bailing`);
+      return null;
+    }
+
+    const checker = this.spellCheckerTable[this._currentSpellCheckerKey];
+    if (!checker) {
+      log.error(`attach: There isn't corresponding dictionary for key '${this._currentSpellCheckerKey}'`);
+      return null;
+    }
+
+    return checker.spellChecker;
   }
 
   /**

--- a/src/spellCheckerProvider.ts
+++ b/src/spellCheckerProvider.ts
@@ -93,7 +93,6 @@ class SpellCheckerProvider {
 
     this.currentSpellCheckerStartTime = Date.now();
     this._currentSpellCheckerKey = key;
-    this.attach(key);
   }
 
   /**
@@ -172,31 +171,6 @@ class SpellCheckerProvider {
 
     delete this.spellCheckerTable[languageKey];
     log.info(`unloadDictionary: dictionary for '${languageKey}' is unloaded`);
-  }
-
-  private attach(key: string): void {
-    const checker = this.spellCheckerTable[key];
-
-    const provider = (text: string) => {
-      const ret = checker.spellChecker.spell(text);
-      if (this._verboseLog) {
-        log.debug(`spellChecker: checking spell for '${text}' with '${key}' returned`, ret);
-      }
-      return ret;
-    };
-    this.setProvider(key, provider);
-  }
-
-  private setProvider(key: string, provider: (text: string) => boolean): void {
-    const webFrame: typeof import('electron').webFrame | null =
-      process.type === 'renderer' ? require('electron').webFrame : null; //tslint:disable-line:no-var-requires no-require-imports
-
-    if (!webFrame) {
-      log.warn(`attach: Cannot lookup webFrame to set spell checker provider`);
-      return;
-    }
-
-    webFrame.setSpellCheckProvider(key, true, { spellCheck: provider });
   }
 
   /**


### PR DESCRIPTION
This PR implements `attachSpellCheckerProvider` function. It takes out job to attach provider via `webFrame.setSpellCheckProvider`. SpellCheckerProvider itself no longer access webFrame in `switchDictionary` to allow can be instantiated outside of renderer process, instead `attachSpellCheckerProvider` being invoked in renderer context accepts proxy to spellcheckerprovider.

Now it separates jobs between instance of spellchecker provider to attach, it makes api surface little bit verbose. But it's necessary to support full-async spellcheck execution outside of renderer process.

- [ ] attachProvider calls switchDictionay for uptime
