### PR TITLE
fix(provider): allow tree shake

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
+  "sideEffects": false,
   "engines": {
     "npm": ">=3.0.0",
     "node": ">=4.2.4"

--- a/src/attachSpellCheckerProvider.ts
+++ b/src/attachSpellCheckerProvider.ts
@@ -1,5 +1,3 @@
-import { log } from './util/logger';
-
 /**
  * Interface to spell checker provider proxy can be accessed from renderer process.
  * `attachSpellCheckProvider` will use this proxy to communicate to actual provider.
@@ -45,7 +43,9 @@ const attachSpellCheckProvider = async (providerProxy: ProviderProxy) => {
 
         completionCallback(spellCheckResult.filter((word => !!word) as (w: any) => w is string));
       } catch (error) {
-        log.error(`spellCheckerCallback: unexpected error occurred ${error.message}`, error);
+        //tslint:disable-next-line:no-console
+        console.error(`spellCheckerCallback: unexpected error occurred ${error.message}`, error);
+        completionCallback([]);
       }
     }
   };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,11 +8,9 @@
     "strictNullChecks": true,
     "noUnusedLocals": true,
     "noImplicitThis": true,
-    "noEmitHelpers": true,
     "noUnusedParameters": true,
     "module": "commonjs",
     "moduleResolution": "node",
-    "importHelpers": true,
     "target": "es5",
     "noEmit": true,
     "lib": [


### PR DESCRIPTION
Need to think about logging strategy, but enabling tree shaking is bit more important.

Somehow, if tslib helper's specified webpack analyzes all imports uses tslib has side effects. disabling it increases some bytes, but better to have tree shaking for attachprovider.