### PR TITLE
Add word to dictionary

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,13 @@ public getSuggestion(text: string): Promise<Readonly<Array<string>>>
 
 It'll ask currently selected spellchecker to get suggestion for misspelling.
 
+To add a word to the dictionary, use `addWord`.  This is *runtime* behavior, so it doesn't 
+persist over once instance is disposed.
+
+```typescript
+public addWord(text: string): Promise<void>
+```
+
 Few other convenient interfaces are available as well.
 
 ```typescript

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ To add a word to the dictionary, use `addWord`.  This is *runtime* behavior, so 
 persist over once instance is disposed.
 
 ```typescript
-public addWord(text: string): Promise<void>
+public addWord(languageKey: string, text: string): Promise<void>
 ```
 
 Few other convenient interfaces are available as well.

--- a/example/main.ts
+++ b/example/main.ts
@@ -28,7 +28,7 @@ const setContextMenuEventHandler = (wnd: Electron.BrowserView | Electron.Browser
       menu.append(
         new MenuItem({
           label: 'Add to dictionary',
-          click: () => wnd!.webContents.executeJavaScript(`${entry}.addWord(\`${p.misspelledWord}\`)`)
+          click: () => wnd!.webContents.executeJavaScript(`${entry}.addWord('en', \`${p.misspelledWord}\`)`)
         })
       );
     }

--- a/example/main.ts
+++ b/example/main.ts
@@ -13,9 +13,8 @@ const setContextMenuEventHandler = (wnd: Electron.BrowserView | Electron.Browser
     } else if (!p.misspelledWord || p.misspelledWord.length < 1) {
       menu.append(new MenuItem({ label: 'no spelling correction suggestion' }));
     } else {
-      const code = `window.${
-        process.env.ENTRY === 'browserWindow' ? 'browserWindowProvider' : 'browserViewProvider'
-      }.getSuggestion(\`${p.misspelledWord}\`)`;
+      const entry = `window.${process.env.ENTRY === 'browserWindow' ? 'browserWindowProvider' : 'browserViewProvider'}`;
+      const code = `${entry}.getSuggestion(\`${p.misspelledWord}\`)`;
       const suggestion = await wnd!.webContents.executeJavaScript(code);
       suggestion.forEach((value: string) => {
         let item = new MenuItem({
@@ -25,6 +24,13 @@ const setContextMenuEventHandler = (wnd: Electron.BrowserView | Electron.Browser
 
         menu.append(item);
       });
+
+      menu.append(
+        new MenuItem({
+          label: 'Add to dictionary',
+          click: () => wnd!.webContents.executeJavaScript(`${entry}.addWord(\`${p.misspelledWord}\`)`)
+        })
+      );
     }
 
     menu.popup({ window: mainWindow! });
@@ -64,7 +70,7 @@ app.on('ready', () => {
     });
     mainWindow.setBrowserView(view);
     view.setBounds({ x: 0, y: 80, width: 1024, height: 768 });
-    view.setAutoResize({ width: true, height: true });
+    view.setAutoResize({ width: true, height: true, horizontal: true, vertical: true });
     view.webContents.loadURL('http://html.com/tags/textarea/#Code_Example');
 
     setTimeout(() => {

--- a/example/worker-main.ts
+++ b/example/worker-main.ts
@@ -26,7 +26,7 @@ const setContextMenuEventHandler = (wnd: Electron.BrowserView | Electron.Browser
       menu.append(
         new MenuItem({
           label: 'Add to dictionary',
-          click: () => wnd!.webContents.executeJavaScript(`window.provider.addWord(\`${p.misspelledWord}\`)`)
+          click: () => wnd!.webContents.executeJavaScript(`window.provider.addWord('en', \`${p.misspelledWord}\`)`)
         })
       );
     }

--- a/example/worker-main.ts
+++ b/example/worker-main.ts
@@ -22,6 +22,13 @@ const setContextMenuEventHandler = (wnd: Electron.BrowserView | Electron.Browser
 
         menu.append(item);
       });
+
+      menu.append(
+        new MenuItem({
+          label: 'Add to dictionary',
+          click: () => wnd!.webContents.executeJavaScript(`window.provider.addWord(\`${p.misspelledWord}\`)`)
+        })
+      );
     }
 
     menu.popup({ window: mainWindow! });
@@ -54,7 +61,7 @@ app.on('ready', () => {
   mainWindow.setBrowserView(view);
 
   view.setBounds({ x: 0, y: 80, width: 1024, height: 768 });
-  view.setAutoResize({ width: true, height: true });
+  view.setAutoResize({ width: true, height: true, horizontal: true, vertical: true });
   view.webContents.loadURL('http://html.com/tags/textarea/#Code_Example');
 
   setTimeout(() => {

--- a/example/worker-preload.ts
+++ b/example/worker-preload.ts
@@ -53,6 +53,20 @@ const init = async () => {
         worker.postMessage({ type: 'getSuggestion', value: text });
       });
     },
+    addWord: (text: string) => {
+      return new Promise<Readonly<Array<string>>>(res => {
+        const responseHandler = (event: MessageEvent) => {
+          const { data } = event;
+          if (data.type === 'addWordResponse') {
+            worker.removeEventListener('message', responseHandler);
+            res(data.value);
+          }
+        };
+
+        worker.addEventListener('addWord', responseHandler);
+        worker.postMessage({ type: 'addWord', value: text });
+      });
+    },
     getSelectedDictionaryLanguage: () => {
       return new Promise<string>(res => {
         const responseHandler = (event: MessageEvent) => {

--- a/example/worker-preload.ts
+++ b/example/worker-preload.ts
@@ -53,8 +53,8 @@ const init = async () => {
         worker.postMessage({ type: 'getSuggestion', value: text });
       });
     },
-    addWord: (text: string) => {
-      return new Promise<Readonly<Array<string>>>(res => {
+    addWord: (languageKey: string, text: string) => {
+      return new Promise<Readonly<void>>(res => {
         const responseHandler = (event: MessageEvent) => {
           const { data } = event;
           if (data.type === 'addWordResponse') {
@@ -64,7 +64,7 @@ const init = async () => {
         };
 
         worker.addEventListener('addWord', responseHandler);
-        worker.postMessage({ type: 'addWord', value: text });
+        worker.postMessage({ type: 'addWord', languageKey, value: text });
       });
     },
     getSelectedDictionaryLanguage: () => {

--- a/example/worker.ts
+++ b/example/worker.ts
@@ -29,7 +29,7 @@ const init = async () => {
         provider.getSuggestion(data.value).then(suggestion => response(data.type, suggestion));
         break;
       case 'addWord':
-        provider.addWord(data.value).then(() => response(data.type));
+        provider.addWord(data.languageKey, data.value).then(() => response(data.type));
         break;
       case 'getSelectedDictionaryLanguage':
         provider.getSelectedDictionaryLanguage().then(dict => response(data.type, dict));

--- a/example/worker.ts
+++ b/example/worker.ts
@@ -28,6 +28,9 @@ const init = async () => {
       case 'getSuggestion':
         provider.getSuggestion(data.value).then(suggestion => response(data.type, suggestion));
         break;
+      case 'addWord':
+        provider.addWord(data.value).then(() => response(data.type));
+        break;
       case 'getSelectedDictionaryLanguage':
         provider.getSelectedDictionaryLanguage().then(dict => response(data.type, dict));
         break;

--- a/package-lock.json
+++ b/package-lock.json
@@ -4301,8 +4301,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4323,14 +4322,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4345,20 +4342,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4475,8 +4469,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4488,7 +4481,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4503,7 +4495,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4511,14 +4502,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4537,7 +4526,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4618,8 +4606,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4631,7 +4618,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4717,8 +4703,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4754,7 +4739,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4774,7 +4758,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4818,14 +4801,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/spec/spellCheckerProvider-spec.ts
+++ b/spec/spellCheckerProvider-spec.ts
@@ -87,6 +87,34 @@ describe('spellCheckerProvider', () => {
     });
   });
 
+  describe('addWord', () => {
+    it('should throw without current checker key', async () => {
+      const provider = new SpellCheckerProvider();
+      expect(provider.addWord('boo')).rejects.toThrow();
+    });
+
+    it('should throw without checker instance', async () => {
+      const provider = new SpellCheckerProvider();
+      (provider as any)._currentSpellCheckerKey = 'kr';
+
+      expect(provider.addWord('boo')).rejects.toThrow();
+    });
+
+    it('add the word', async () => {
+      const provider = new SpellCheckerProvider();
+
+      const spellChecker = {
+        addWord: jest.fn()
+      };
+
+      (provider as any)._currentSpellCheckerKey = 'kr';
+      (provider as any).spellCheckerTable['kr'] = { spellChecker };
+
+      await provider.addWord('boo');
+      expect(spellChecker.addWord).toHaveBeenCalledWith('boo');
+    });
+  });
+
   describe('loadDictionary', async () => {
     it('should throw when key is not valid', async () => {
       const provider = new SpellCheckerProvider();

--- a/spec/spellCheckerProvider-spec.ts
+++ b/spec/spellCheckerProvider-spec.ts
@@ -88,16 +88,11 @@ describe('spellCheckerProvider', () => {
   });
 
   describe('addWord', () => {
-    it('should throw without current checker key', async () => {
-      const provider = new SpellCheckerProvider();
-      expect(provider.addWord('boo')).rejects.toThrow();
-    });
-
     it('should throw without checker instance', async () => {
       const provider = new SpellCheckerProvider();
       (provider as any)._currentSpellCheckerKey = 'kr';
 
-      expect(provider.addWord('boo')).rejects.toThrow();
+      expect(provider.addWord('en', 'boo')).rejects.toThrow();
     });
 
     it('add the word', async () => {
@@ -110,7 +105,7 @@ describe('spellCheckerProvider', () => {
       (provider as any)._currentSpellCheckerKey = 'kr';
       (provider as any).spellCheckerTable['kr'] = { spellChecker };
 
-      await provider.addWord('boo');
+      await provider.addWord('kr', 'boo');
       expect(spellChecker.addWord).toHaveBeenCalledWith('boo');
     });
   });

--- a/src/attachSpellCheckProvider.ts
+++ b/src/attachSpellCheckProvider.ts
@@ -20,6 +20,10 @@ interface ProviderProxy {
    * Returns currently selected spellchecker dictionary language.
    */
   getSelectedDictionaryLanguage: () => Promise<string | null>;
+  /**
+   * Add a word to the current dictionary.
+   */
+  addWord: (text: string) => Promise<void>;
 }
 
 /**

--- a/src/attachSpellCheckProvider.ts
+++ b/src/attachSpellCheckProvider.ts
@@ -23,7 +23,7 @@ interface ProviderProxy {
   /**
    * Add a word to the current dictionary.
    */
-  addWord: (text: string) => Promise<void>;
+  addWord?: (languageKey: string, text: string) => Promise<void>;
 }
 
 /**

--- a/src/spellCheckerProvider.ts
+++ b/src/spellCheckerProvider.ts
@@ -118,13 +118,12 @@ class SpellCheckerProvider {
    * @param {string} text: word to be added
    * @returns {Promise<void>} Indication to load completes.
    */
-  public async addWord(text: string): Promise<void> {
-    const spellChecker = this.getSpellchecker();
-    if (!spellChecker) {
-      throw new Error('Not able to find spellchecker');
+  public async addWord(languageKey: string, text: string): Promise<void> {
+    if (!languageKey || !this.spellCheckerTable[languageKey]) {
+      throw new Error(`Spellchecker dictionary for ${languageKey} is not available, ensure dictionary loaded`);
     }
 
-    return spellChecker.addWord(text);
+    return this.spellCheckerTable[languageKey].spellChecker.addWord(text);
   }
 
   /**

--- a/src/spellCheckerProvider.ts
+++ b/src/spellCheckerProvider.ts
@@ -100,7 +100,7 @@ class SpellCheckerProvider {
 
   /**
    * Get suggestion for misspelled text.
-   * @param {string} Text text to get suggstion.
+   * @param {string} Text text to get suggestion.
    * @returns {Readonly<Array<string>>} Array of suggested values.
    */
   public async getSuggestion(text: string): Promise<Readonly<Array<string>>> {
@@ -110,6 +110,21 @@ class SpellCheckerProvider {
     }
 
     return spellChecker.suggest(text);
+  }
+
+  /**
+   * Add a word to the current dictionary.
+   * Runtime only -- added words do not persist between sessions!
+   * @param {string} text: word to be added
+   * @returns {Promise<void>} Indication to load completes.
+   */
+  public async addWord(text: string): Promise<void> {
+    const spellChecker = this.getSpellchecker();
+    if (!spellChecker) {
+      throw new Error('Not able to find spellchecker');
+    }
+
+    return spellChecker.addWord(text);
   }
 
   /**

--- a/src/spellCheckerProvider.ts
+++ b/src/spellCheckerProvider.ts
@@ -115,6 +115,7 @@ class SpellCheckerProvider {
   /**
    * Add a word to the current dictionary.
    * Runtime only -- added words do not persist between sessions!
+   * @param {string} languageKey Locale key for spell checker instance.
    * @param {string} text: word to be added
    * @returns {Promise<void>} Indication to load completes.
    */


### PR DESCRIPTION
This implements the `addWord` functionality.    It doesn't try to persist added words between sessions; instead, this is left to the consumer.  

Tests, examples and docs also updated.

Thanks for this welcome addition to electron spellchecking options!!   It's quickly becoming the best available out there. 


 